### PR TITLE
Docs: gurantees dox returns all given keys

### DIFF
--- a/singleflightx.go
+++ b/singleflightx.go
@@ -7,7 +7,7 @@ import "runtime"
 // time. If a duplicate comes in, the duplicate caller waits for the
 // original to complete and receives the same results.
 // The return value shared indicates whether v was given to multiple callers.
-// Even if fn does not return v on some keys, the results map will contain
+// Even if fn does not return V on some keys, the results map will contain
 // those keys with a `Valid` field set to false.
 func (g *Group[K, V]) DoX(keys []K, fn func([]K) (map[K]V, error)) (results map[K]Result[V]) {
 	results = make(map[K]Result[V], len(keys))

--- a/singleflightx.go
+++ b/singleflightx.go
@@ -7,6 +7,8 @@ import "runtime"
 // time. If a duplicate comes in, the duplicate caller waits for the
 // original to complete and receives the same results.
 // The return value shared indicates whether v was given to multiple callers.
+// Even if fn does not return v on some keys, the results map will contain
+// those keys with a `Valid` field set to false.
 func (g *Group[K, V]) DoX(keys []K, fn func([]K) (map[K]V, error)) (results map[K]Result[V]) {
 	results = make(map[K]Result[V], len(keys))
 	calls := make(map[K]*call[V], len(keys))


### PR DESCRIPTION
Hi! 

I'm confused that `DoX`
- returns all `Result` to given keys

or

- returns only partial `Result` if `fn` returns only partial result. So i need post processing to what is missing.

But i found the test case cover it. 
Comment that `DoX` gurantees returning all `Result` to given keys is helpful someone like me. 
